### PR TITLE
Add duration argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const cmdRegistry = {};
 
 const path = require("path");
 const rqAll = require("require-all");
+const dur = require("parse-duration");
 
 function defaulter(val, defaultTo) {
 	if (!defaultTo) {

--- a/index.js
+++ b/index.js
@@ -237,6 +237,10 @@ const argTypes = {
 		}
 
 		getValue(value, args) {
+			if (value === undefined) {
+				return undefined;
+			}
+
 			try {
 				return dur(value);
 			} catch (error) {

--- a/index.js
+++ b/index.js
@@ -223,6 +223,21 @@ const argTypes = {
 			this.custom(...arguments);
 		}
 	},
+	duration: class extends Argument {
+		constructor(argument) {
+			super(argument);
+
+			this.type = "duration";
+		}
+
+		getValue(value, args) {
+			try {
+				return dur(value);
+			} catch (error) {
+				return new InvalidArgumentError(this.constructor, args, "duration_argument_invalid", this, value);
+			}
+		}
+	},
 	generic: Argument,
 	integer: class extends Argument {
 		constructor(argument) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,13 @@ const cmdRegistry = {};
 
 const path = require("path");
 const rqAll = require("require-all");
+
 const dur = require("parse-duration");
+
+// Add some extra (large) units
+dur.decade = dur.dec = (dur.year * 10);
+dur.century = dur.cen = (dur.decade * 10);
+dur.millennium = dur.mil = (dur.century * 10);
 
 function defaulter(val, defaultTo) {
 	if (!defaultTo) {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "@snooful/orangered-parser",
 	"description": "A simple command parser made specifically for Snooful.",
 	"dependencies": {
+		"parse-duration": "^0.1.1",
 		"require-all": "^3.0.0"
 	},
 	"version": "2.0.0",


### PR DESCRIPTION
This pull request lets commands have durations as arguments. These can take any format/units provided by the [`parse-duration`](https://github.com/jkroso/parse-duration) library, plus ones for larger amounts of time (decades, centuries, and millennia).