### PR TITLE
Use a map for the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,22 @@ parse.parse("nodejs 11", {
 
 ### Accessing the Registry
 
+You can access the command registry by calling `parser.getCommandRegistry()`. This provides you with a [`Map`](http://www.collectionsjs.com/map).
+
 ```js
-// Get a registered command
-parser.getCommandRegistry().get("code");
+const registry = parser.getCommandRegistry();
+```
+
+To get a command from the registry, simply call `registry.get(command)`.
+
+```js
+const cmd = registry.get("code");
+```
+
+You can filter out aliases by checking if the command's original name is the same as its name:
+
+```js
+registry.filter(command => {
+	return command.originalName !== command.name;
+});
 ```

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-const cmdRegistry = {};
+const Map = require("collections/map");
+const cmdRegistry = new Map();
 
 const path = require("path");
 const rqAll = require("require-all");
@@ -198,7 +199,7 @@ const argTypes = {
 				return undefined;
 			}
 
-			const cmd = cmdRegistry[value];
+			const cmd = cmdRegistry.get(value);
 			if (cmd) {
 				if (!this.allowAlias && cmd.name !== cmd.originalName) {
 					return new InvalidArgumentError(this.constructor, args, "command_argument_not_original", this, value);
@@ -308,7 +309,7 @@ class Command {
 /**
  * Registers a single command.
  * @param {(object|Command)} cmd The command to register.
- * @returns {object} The registry including the new command.
+ * @returns {Map} The registry including the new command.
  */
 function register(cmd) {
 	const name = findName(cmd);
@@ -328,7 +329,7 @@ function register(cmd) {
 
 			// Make it into a Command and actually add it to the registry
 			const cmdFixed = typeof cmd === "object" ? new Command(cmd) : cmd;
-			cmdRegistry[aname] = cmdFixed;
+			cmdRegistry.set(aname, cmdFixed);
 		});
 
 		return cmdRegistry;
@@ -339,7 +340,7 @@ function register(cmd) {
 	* Registers every JavaScript file in a directory as a command.
 	* @param {string} directory The path to the directory to register.
 	* @param {boolean} recursive If true, registers commands in subdirectories.
- 	* @returns {object} The registry including the new commands.
+ 	* @returns {Map} The registry including the new commands.
 
 */
 function registerDirectory(directory = "", recursive = true) {
@@ -363,7 +364,7 @@ function parse(command, pass) {
 	const parts = cmd.match(/(?:[^\s"]+|"[^"]*")+/g);
 
 	if (parts.length > 0) {
-		const cmdSource = cmdRegistry[parts[0]];
+		const cmdSource = cmdRegistry.get(parts[0]);
 		if (cmdSource) {
 			const args = parts.slice(1);
 			const argsObj = Object.assign({}, pass);
@@ -401,7 +402,7 @@ module.exports = {
 	Command,
 	argTypes,
 	getCommandRegistry() {
-		return Object.values(cmdRegistry);
+		return cmdRegistry;
 	},
 	parse,
 	register,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "@snooful/orangered-parser",
 	"description": "A simple command parser made specifically for Snooful.",
 	"dependencies": {
+		"collections": "^5.1.5",
 		"require-all": "^3.0.0"
 	},
 	"version": "2.0.0",


### PR DESCRIPTION
This pull request switches the command registry from a regular object to a [`Map`](http://www.collectionsjs.com/map) as provided by [Collections.js](http://www.collectionsjs.com/).